### PR TITLE
Fix empty file bug

### DIFF
--- a/file_resubmit/cache.py
+++ b/file_resubmit/cache.py
@@ -22,6 +22,7 @@ class FileCache(object):
         return get_cache('file_resubmit')
 
     def set(self, key, upload):
+        upload.file.seek(0)
         state = {
             "name": upload.name,
             "size": upload.size,


### PR DESCRIPTION
If file was read before, the "content" of cache would be empty