### PR TITLE
Django1.11 compatability alternate fix

### DIFF
--- a/file_resubmit/widgets.py
+++ b/file_resubmit/widgets.py
@@ -2,7 +2,7 @@
 import os
 import uuid
 
-from django import forms
+from django import forms, get_version
 from django.forms.widgets import FILE_INPUT_CONTRADICTION
 from django.conf import settings
 from django.forms import ClearableFileInput
@@ -57,8 +57,14 @@ class ResubmitBaseWidget(ClearableFileInput):
 
 
 class ResubmitFileWidget(ResubmitBaseWidget):
-    template_with_initial = ClearableFileInput.template_with_initial
-    template_with_clear = ClearableFileInput.template_with_clear
+
+    def __init__(self, *args, **kwargs):
+        super(ResubmitFileWidget, self).__init__(*args, **kwargs)
+        version = get_version()
+        version_lt_11 = int(version.split('.')[1]) < 11
+        if version_lt_11:
+            self.template_with_initial = ClearableFileInput.template_with_initial
+            self.template_with_clear = ClearableFileInput.template_with_clear
 
     def render(self, name, value, attrs=None):
         output = ClearableFileInput.render(self, name, value, attrs)

--- a/file_resubmit/widgets.py
+++ b/file_resubmit/widgets.py
@@ -74,12 +74,20 @@ class ResubmitFileWidget(ResubmitBaseWidget):
         else:
             return ''
 
+    @template_with_initial.setter
+    def template_with_initial(self, value):
+        self._template_with_initial = value
+
     @property
     def template_with_clear(self):
         if hasattr(self, '_template_with_clear'):
             return self._template_with_clear
         else:
             return ''
+
+    @template_with_clear.setter
+    def template_with_clear(self, value):
+        self._template_with_clear = value
 
     def render(self, name, value, attrs=None):
         output = ClearableFileInput.render(self, name, value, attrs)

--- a/file_resubmit/widgets.py
+++ b/file_resubmit/widgets.py
@@ -60,11 +60,26 @@ class ResubmitFileWidget(ResubmitBaseWidget):
 
     def __init__(self, *args, **kwargs):
         super(ResubmitFileWidget, self).__init__(*args, **kwargs)
-        version = get_version()
-        version_lt_11 = int(version.split('.')[1]) < 11
-        if version_lt_11:
-            self.template_with_initial = ClearableFileInput.template_with_initial
-            self.template_with_clear = ClearableFileInput.template_with_clear
+        try:
+            self._template_with_initial = ClearableFileInput.template_with_initial
+            self._template_with_clear = ClearableFileInput.template_with_clear
+        except AttributeError:
+            self._template_with_clear = ''
+            self._template_with_initial = ''
+
+    @property
+    def template_with_initial(self):
+        if hasattr(self, '_template_with_initial'):
+            return self._template_with_initial
+        else:
+            return ''
+
+    @property
+    def template_with_clear(self):
+        if hasattr(self, '_template_with_clear'):
+            return self._template_with_clear
+        else:
+            return ''
 
     def render(self, name, value, attrs=None):
         output = ClearableFileInput.render(self, name, value, attrs)

--- a/file_resubmit/widgets.py
+++ b/file_resubmit/widgets.py
@@ -2,7 +2,7 @@
 import os
 import uuid
 
-from django import forms, get_version
+from django import forms
 from django.forms.widgets import FILE_INPUT_CONTRADICTION
 from django.conf import settings
 from django.forms import ClearableFileInput


### PR DESCRIPTION
I was thinking about it more, and I consider this to be a more failsafe approach to resolving the Django 1.11 incompatibility issue. I've added a couple of `@property` methods to the ResubmitFileWidget and instead of checking the Django version in the `__init__` method, I'm just using a try/except statement. Even though the previous method worked for me, since I don't know if there would be any compatibility issues with the `get_version` method. This fixes #16  