### PR TITLE
Resolve issue with renderer (django 2)

### DIFF
--- a/file_resubmit/widgets.py
+++ b/file_resubmit/widgets.py
@@ -60,7 +60,7 @@ class ResubmitFileWidget(ResubmitBaseWidget):
     template_with_initial = getattr(ClearableFileInput, 'template_with_initial', '')
     template_with_clear = getattr(ClearableFileInput, 'template_with_clear', '')
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None, **kwargs):
         output = ClearableFileInput.render(self, name, value, attrs)
         output += self.output_extra_data(value)
         return mark_safe(output)


### PR DESCRIPTION
Add compatybility with django 2

Error:
`TypeError: render() got an unexpected keyword argument 'renderer'`

Same as:
`https://github.com/yourlabs/django-autocomplete-light/pull/1028/commits/c7cfb00cccf9babc6fa17d7de938484b8e467744`

