### PR TITLE
Fix: attrs should be passed to __init__() of ResubmitBaseWidget's super class

### DIFF
--- a/file_resubmit/widgets.py
+++ b/file_resubmit/widgets.py
@@ -12,7 +12,7 @@ from .cache import FileCache
 
 class ResubmitBaseWidget(ClearableFileInput):
     def __init__(self, attrs=None, field_type=None):
-        super(ResubmitBaseWidget, self).__init__()
+        super(ResubmitBaseWidget, self).__init__(attrs=attrs)
         self.cache_key = ''
         self.field_type = field_type
 


### PR DESCRIPTION
Hi un1t, thanks for your great library.

I'd like to specify `attrs` in `ResubmitFileWidget` just like `FileInput(attrs={'accept': 'image/*'})`.

```python
ImageField(widget=ResubmitFileWidget(attrs={'accept': 'image/*'}))
```

This PR allows us to reflect the given argument.

## Note: Inheritance hierarchy

1. django.forms.Input
2. -> django.forms.FileInput
3. -> django.forms.ClearableFileInput
4. -> ResubmitBaseWidget

```python
# https://github.com/django/django/blob/master/django/forms/widgets.py

class Input(Widget):
    def __init__(self, attrs=None):
        if attrs is not None:
            attrs = attrs.copy()
            self.input_type = attrs.pop('type', self.input_type)
        super().__init__(attrs)
```


